### PR TITLE
Fix margin top for input field in combination with icon, label and input-control

### DIFF
--- a/src/core/forms.scss
+++ b/src/core/forms.scss
@@ -221,6 +221,10 @@ label {
         margin-top: 0.8rem;
     }
 
+    & + .input-control {
+        margin-top: 0;
+    }
+
     &.label:not(:last-child) {
         margin-bottom: 0;
     }

--- a/src/core/forms.scss
+++ b/src/core/forms.scss
@@ -221,7 +221,7 @@ label {
         margin-top: 0.8rem;
     }
 
-    & + .input-control {
+    + .input-control {
         margin-top: 0;
     }
 


### PR DESCRIPTION
- Fixed a minor issue: whenever using a icon and label with input-control there was a not good looking margin-top

# Description

There is an issue when putting an icon and label in combination with an input field. Because of the input-control class there will be a not good looking margin between the label and the input field. I've fixed this by adding a margin-top 0 whenever there is a label above the input-control class.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This has been tested by creating a input field with a icon and a label:
```html
<label>Test Label</label>
<div class="input-control">
  <input type="text" class="input-contains-icon" placeholder="Test">
  <span class="icon">A</span>
</div>
```

Current behaviour:
![image](https://user-images.githubusercontent.com/20746070/98516537-efce0200-226c-11eb-88ee-3a5eafe8e1f6.png)

Expected behaviour:
![image](https://user-images.githubusercontent.com/20746070/98516494-db8a0500-226c-11eb-84d6-3b6a375d3425.png)