### PR TITLE
Fix cursor not allowed for disabled buttons

### DIFF
--- a/src/core/button.scss
+++ b/src/core/button.scss
@@ -50,7 +50,10 @@
     &:disabled {
         cursor: not-allowed;
         opacity: 0.5;
-        pointer-events: none;
+
+        &:active {
+            pointer-events: none;
+        }
     }
 
     &.outline {


### PR DESCRIPTION
# Description

Disabled buttons don't have a not allowed cursor. It does not work because `pointer-events` and `cursor` collapse.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested with multiple buttons in a disabled and not disabled state.