### PR TITLE
New group rounded feature and small color fix control themes

### DIFF
--- a/src/core/theme.scss
+++ b/src/core/theme.scss
@@ -30,6 +30,7 @@ $cirrus-warning-hover: #f9a90e;
 $cirrus-danger-hover: #f1393c;
 
 $control-themes: (
+    'primary': $cirrus-primary,
     'gray': $cirrus-gray,
     'dark': $cirrus-dark,
     'link': $cirrus-link,

--- a/src/ext/tags.scss
+++ b/src/ext/tags.scss
@@ -151,31 +151,33 @@
     }
 
     /* Used for grouping tags together */
-    &.group-tags .tag,
-    &.group-tags--rounded .tag {
-        margin-right: 0 !important;
+    &.group-tags {
+        .tag,
+        &--rounded .tag {
+            margin-right: 0 !important;
 
-        &:first-child {
-            border-radius: 0.25rem 0 0 0.25rem;
+            &:first-child {
+                border-radius: 0.25rem 0 0 0.25rem;
+            }
+
+            &:not(:first-child):not(:last-child) {
+                border-radius: 0;
+            }
+
+            &:last-child {
+                border-radius: 0 0.25rem 0.25rem 0;
+            }
         }
 
-        &:not(:first-child):not(:last-child) {
-            border-radius: 0;
-        }
+        // Round first and last tag in the grouped tags
+        &--rounded .tag {
+            &:first-child {
+                border-radius: 290486px 0 0 290486px;
+            }
 
-        &:last-child {
-            border-radius: 0 0.25rem 0.25rem 0;
-        }
-    }
-
-    /* Round first and last tag in the grouped tags */
-    &.group-tags--rounded .tag {
-        &:first-child {
-            border-radius: 290486px 0 0 290486px;
-        }
-
-        &:last-child {
-            border-radius: 0 290486px 290486px 0;
+            &:last-child {
+                border-radius: 0 290486px 290486px 0;
+            }
         }
     }
 

--- a/src/ext/tags.scss
+++ b/src/ext/tags.scss
@@ -151,19 +151,31 @@
     }
 
     /* Used for grouping tags together */
-    &.group-tags .tag {
-        margin-right: 0 !important;
+    &.group-tags {
+        /* Round first and last tag in the grouped tags */
+        &.group-rounded {
+            .tag:first-child {
+                border-radius: 290486px 0 0 290486px;
+            }
+            .tag:last-child {
+                border-radius: 0 290486px 290486px 0;
+            }
+        }
 
-        &:first-child {
-            border-radius: 0.25rem 0 0 0.25rem;
-        }
-    
-        &:not(:first-child):not(:last-child) {
-            border-radius: 0;
-        }
-    
-        &:last-child {
-            border-radius: 0 0.25rem 0.25rem 0;
+        .tag {
+            margin-right: 0 !important;
+
+            &:first-child {
+                border-radius: 0.25rem 0 0 0.25rem;
+            }
+        
+            &:not(:first-child):not(:last-child) {
+                border-radius: 0;
+            }
+        
+            &:last-child {
+                border-radius: 0 0.25rem 0.25rem 0;
+            }
         }
     }
 

--- a/src/ext/tags.scss
+++ b/src/ext/tags.scss
@@ -152,7 +152,7 @@
 
     /* Used for grouping tags together */
     &.group-tags {
-        /* Round first and last tag in the grouped tags */
+        // Round first and last tag in the grouped tags
         &.group-rounded {
             .tag:first-child {
                 border-radius: 290486px 0 0 290486px;

--- a/src/ext/tags.scss
+++ b/src/ext/tags.scss
@@ -151,31 +151,31 @@
     }
 
     /* Used for grouping tags together */
-    &.group-tags {
-        // Round first and last tag in the grouped tags
-        &.group-rounded {
-            .tag:first-child {
-                border-radius: 290486px 0 0 290486px;
-            }
-            .tag:last-child {
-                border-radius: 0 290486px 290486px 0;
-            }
+    &.group-tags .tag,
+    &.group-tags--rounded .tag {
+        margin-right: 0 !important;
+
+        &:first-child {
+            border-radius: 0.25rem 0 0 0.25rem;
         }
 
-        .tag {
-            margin-right: 0 !important;
+        &:not(:first-child):not(:last-child) {
+            border-radius: 0;
+        }
 
-            &:first-child {
-                border-radius: 0.25rem 0 0 0.25rem;
-            }
-        
-            &:not(:first-child):not(:last-child) {
-                border-radius: 0;
-            }
-        
-            &:last-child {
-                border-radius: 0 0.25rem 0.25rem 0;
-            }
+        &:last-child {
+            border-radius: 0 0.25rem 0.25rem 0;
+        }
+    }
+
+    /* Round first and last tag in the grouped tags */
+    &.group-tags--rounded .tag {
+        &:first-child {
+            border-radius: 290486px 0 0 290486px;
+        }
+
+        &:last-child {
+            border-radius: 0 290486px 290486px 0;
         }
     }
 


### PR DESCRIPTION
# Description

Sorry for so much PR's :D 

I've added a common use case for actual rounding group tags. I think it should be pretty useful for some use cases. Furthermore, there are rounded tags so why not having grouped rounded tags ;)

In addition, I've added the primary color to the control themes. This fix resolved that primary colored closing tags are not clickable.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

You can see the result of the new rounded grouping tags in the image below:
![image](https://user-images.githubusercontent.com/20746070/98916255-3a4cba00-24cb-11eb-9402-07076fbdef8f.png)

1. tag container without grouped or rounded
2. grouped tag container
3. grouped and rounded tag container