### PR TITLE
chore: missing prefix in Text Center code example

### DIFF
--- a/cirrus-docs-next/src/utilities/misc/index.tsx
+++ b/cirrus-docs-next/src/utilities/misc/index.tsx
@@ -267,7 +267,7 @@ position: absolute;`,
                         </div>
 
                         <div className="space"></div>
-                        <CodeBlock code={`<p class="text-center">This is some text.</p>`} language="htmlbars" />
+                        <CodeBlock code={`<p class="u-text-center">This is some text.</p>`} language="htmlbars" />
                         <div className="space large"></div>
 
                         <h6>Text Right</h6>


### PR DESCRIPTION
# Description

missing `u-` in code Text Center example

![image](https://user-images.githubusercontent.com/7860859/136015213-bac5afdc-4098-4c7c-b88e-28c6a74c89f0.png)
