### PR TITLE
Docs-fix: vertical label divider example

### DIFF
--- a/cirrus-docs-next/src/layout/divider/index.tsx
+++ b/cirrus-docs-next/src/layout/divider/index.tsx
@@ -92,12 +92,12 @@ export const DividerPage: React.FC<any> = (props) => {
                         <div className="row">
                             <div className="col-lg-6">
                                 <div style={{ position: 'relative', height: '300px' }}>
-                                    <div className="divider--v h-100pp" data-content="Label" />
+                                    <div className="divider--v h-100p" data-content="Label" />
                                 </div>
                             </div>
                             <div className="col-lg-6">
                                 <CodeBlock
-                                    code={`<div class="divider--v h-100pp" data-content="Label" />`}
+                                    code={`<div class="divider--v h-100p" data-content="Label" />`}
                                     language="htmlbars"
                                 />
                             </div>


### PR DESCRIPTION
# Description

Fixes a typo to give the vertical label divider example the look it deserves.

Fixes #165

## Type of change

- [x] Documentation visual error fix

# How Has This Been Tested?

I made the changes locally in my inspector first. It's a classname typo, I didn't do much more.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules